### PR TITLE
Fix issue #30

### DIFF
--- a/demos/decisions/index.html
+++ b/demos/decisions/index.html
@@ -35,7 +35,7 @@
 					<p property="argument">Fun with friends!</p>
 					<p>
 						Weight:
-						<meter property="weight" min="1" value="1" max="5"></meter>
+						<meter property="weight" min="1" mv-default="1" max="5"></meter>
 						[weight]
 					</p>
 				</li>
@@ -49,7 +49,7 @@
 					<p property="argument">I have tons of work to do.</p>
 					<p>
 						Weight:
-						<meter property="weight" min="1" value="1" max="5"></meter>
+						<meter property="weight" min="1" mv-default="1" max="5"></meter>
 						[weight]
 					</p>
 				</li>


### PR DESCRIPTION
I don't know why the `weight` property value not equal to the `value` attribute value by default, but anyway that PR would fix the bug in this app.