### PR TITLE
Suggested edits to data

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -1545,7 +1545,7 @@
 							"name": "options",
 							"optional": true,
 							"type": "Object",
-							"description": "Options to customize the behavior of the message:\n\n| Name | Type | Description |\n| ---------|--------|---------|\nclasses | `String` | Class(es) to add to the message (space-separated). You may find `mv-inline` useful here. \ndismiss | `String` or `Array<String>` or `Object` | If the message is dismissable, what should dismiss it? Options: `\"button\"`: x close button, `\"timeout\"` (after 5s or whatever specified), `\"submit\"` (submit event — useful if the message contains a form)"
+							"description": "Options to customize the behavior of the message:\n\n| Name | Type | Description |\n| ---------|--------|---------|\ntype | `String` | One of the predefined message styles. Possible values: `warning`, `error`. You may find the `.mv-message::before` selector useful here to change/remove/style the text added by Mavo *before* the message.\nclasses | `String` | Class(es) to add to the message (space-separated). You may find `mv-inline` useful here. \ndismiss | `String` or `Array<String>` or `Object` | If the message is dismissable, what should dismiss it? Options: `\"button\"`: x close button, `\"timeout\"` (after 5s or whatever specified), `\"submit\"` (submit event — useful if the message contains a form)"
 						}
 					],
 					"name": "new Mavo.UI.Message"


### PR DESCRIPTION
Hello there! I used Mavo to suggest the following edits:
I added the description of the `type` property of the `options` object of the `Mavo.UI.Message` class. I find it useful to know that there is a couple of predefined message styles I can use out of the box.
Preview my changes here: https://mavo.io/docs/api/?storage=https%3A%2F%2Fraw.githubusercontent.com%2FDmitrySharabin%2Fmavo.io%2Fmaster%2Fdocs%2Fapi%2Fapi.json&api-storage=https%3A%2F%2Fgithub.com%2Fmavoweb%2Fmavo.io%2Fdocs%2Fapi%2Fapi.json