### PR TITLE
Fixes issues with <option> introduced by mavo#564

### DIFF
--- a/demos/talks/index.html
+++ b/demos/talks/index.html
@@ -48,7 +48,7 @@
 
 <div hidden mv-app mv-init="https://leaverou.github.io/countries.json">
 	<select id="countries">
-		<option value="[code]" property="country" mv-multiple typeof>[name]</option>
+		<option value="[code]" property="country" mv-multiple typeof mv-attribute="none">[name]</option>
 	</select>
 </div>
 

--- a/demos/worldsum/index.html
+++ b/demos/worldsum/index.html
@@ -30,7 +30,7 @@
 					<option value="USD">$</option>
 					<option value="EUR">€</option>
 					<option value="GBP">£</option>
-					<option mv-multiple="currency" mv-value="Object.keys(Currency.rates)"></option>
+					<option mv-multiple="currency" mv-value="Object.keys(Currency.rates)" mv-attribute="none"></option>
 				</select></th>
 			</tr>
 		</thead>

--- a/docs/functions/index.html
+++ b/docs/functions/index.html
@@ -66,7 +66,7 @@
 					group(id: 'datetime', text: 'Dates and Times'),
 					group(id: 'logical', text: 'Logical'),
 					group(id: 'other', text: 'Other'),
-				)" value="[id]">[text]</option>
+				)" mv-attribute="none" value="[id]">[text]</option>
 			</select>
 		</fieldset>
 	</div>

--- a/docs/functions/index.tpl.html
+++ b/docs/functions/index.tpl.html
@@ -37,7 +37,7 @@
 					group(id: 'datetime', text: 'Dates and Times'),
 					group(id: 'logical', text: 'Logical'),
 					group(id: 'other', text: 'Other'),
-				)" value="[id]">[text]</option>
+				)" mv-attribute="none" value="[id]">[text]</option>
 			</select>
 		</fieldset>
 	</div>

--- a/get/index.html
+++ b/get/index.html
@@ -81,7 +81,7 @@
 				<input type="radio" name="path" value="[version]/">
 				Far from it, I actually want a <a href="#releases">specific version</a>:
 				<select property="version">
-					<option mv-multiple="versions" mv-value="first(count(releases.tag_name), releases.tag_name)" selected="[$index = 1]">0.1.5</option>
+					<option mv-multiple="versions" mv-value="first(count(releases.tag_name), releases.tag_name)" selected="[$index = 1]">[from($item, v)]</option>
 				</select>
 			</label>
 		</article>

--- a/get/index.tpl.html
+++ b/get/index.tpl.html
@@ -50,7 +50,7 @@
 				<input type="radio" name="path" value="[version]/">
 				Far from it, I actually want a <a href="#releases">specific version</a>:
 				<select property="version">
-					<option mv-multiple="versions" mv-value="first(count(releases.tag_name), releases.tag_name)" selected="[$index = 1]">0.1.5</option>
+					<option mv-multiple="versions" mv-value="first(count(releases.tag_name), releases.tag_name)" selected="[$index = 1]">[from($item, v)]</option>
 				</select>
 			</label>
 		</article>


### PR DESCRIPTION
The issue mavo#564 broke the Mavo site (see the corresponding select elements): https://mavo.io/docs/functions/ and https://mavo.io/get/. This PR fixes it.