### PR TITLE
Update markdown-docs.js

### DIFF
--- a/js/markdown-docs.js
+++ b/js/markdown-docs.js
@@ -131,7 +131,7 @@ ${html}
 					title: "Play with this example on codepen.io",
 					events: {
 						// This shouldn't be needed but for some reason the form won't submit otherwise
-						click: function(evt) { this.form.submit(); }
+						click: function(evt) {}
 					}
 				}
 			],


### PR DESCRIPTION
 Deleting "this.form.submit();" fixes the two-tab opening bug on 'Play!' buttons in the Chrome browser.