### PR TITLE
Migrate from mv-edit* to mv-editor*

### DIFF
--- a/demos/foodie/index.html
+++ b/demos/foodie/index.html
@@ -47,7 +47,7 @@
 						<p property="name">Filet mignon with black truffle and foie gras</p>
 						<p>
 							Rating:
-							<meter property="dishRating" min="0" value="4" max="5" mv-edit-step="0.5"></meter>
+							<meter property="dishRating" min="0" value="4" max="5" mv-editor-step="0.5"></meter>
 							[dishRating]
 						</p>
 					</li>

--- a/demos/invoice/index.html
+++ b/demos/invoice/index.html
@@ -66,7 +66,7 @@
 			<thead>
 				<tr>
 					<td>Description</td>
-					<td>Amount (<span property="currency" mv-edit="#currencies"></span>)</td>
+					<td>Amount (<span property="currency" mv-editor="#currencies"></span>)</td>
 				</tr>
 			</thead>
 			<tbody>

--- a/demos/lottery/index.html
+++ b/demos/lottery/index.html
@@ -23,7 +23,7 @@
 
 </section>
 <section class="winners">
-	<h1>The <span property="winnerCount" datatype=number mv-edit-min="1" mv-edit-max="count(name)">1</span> Winner[if(winnerCount != 1, 's')]
+	<h1>The <span property="winnerCount" datatype=number mv-editor-min="1" mv-editor-max="count(name)">1</span> Winner[if(winnerCount != 1, 's')]
 	</h1>
 	<ul>
 		<li property=winner mv-multiple mv-mode="read" mv-storage="none" mv-initial-items="0" class="person"></li>

--- a/demos/talks/index.html
+++ b/demos/talks/index.html
@@ -18,7 +18,7 @@
 		<meta property="upcoming" content="[date > $now]" />
 		<h1 mv-multiple property="talk">
 			<span property="title" mv-default>TBD</span>
-			<span property class="type" mv-edit="#talk-type"></span>
+			<span property class="type" mv-editor="#talk-type"></span>
 			<a property class="video" target="_blank">Video</a>
 			<a property class="slides" target="_blank">Slides</a>
 		</h1>
@@ -30,7 +30,7 @@
 		<p class="date"><time property="date"></time></p>
 		<address class="flag-[country]">
 			<span property="city"></span>,
-			<span property="country" mv-edit="#countries"></span>
+			<span property="country" mv-editor="#countries"></span>
 		</address>
 		<p class="comment" property></p>
 		<p class="comment" style="display: [iff(feedback, block, none)]">

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -86,7 +86,7 @@
 				<span property="type" mv-if="role != 'constructor' and role != 'function'" foo="role != 'function'"></span>
 				<span class="type">[returnType]</span>
 				<span property="static" class="mv-toggle" mv-if="role != 'constructor'">Static</span>
-				<span property="role" mv-edit="#role-select"></span>
+				<span property="role" mv-editor="#role-select"></span>
 			</summary>
 
 			<p property="description" class="markdown"></p>

--- a/docs/api/index.tpl.html
+++ b/docs/api/index.tpl.html
@@ -57,7 +57,7 @@
 				<span property="type" mv-if="role != 'constructor' and role != 'function'" foo="role != 'function'"></span>
 				<span class="type">[returnType]</span>
 				<span property="static" class="mv-toggle" mv-if="role != 'constructor'">Static</span>
-				<span property="role" mv-edit="#role-select"></span>
+				<span property="role" mv-editor="#role-select"></span>
 			</summary>
 
 			<p property="description" class="markdown"></p>

--- a/docs/functions/index.html
+++ b/docs/functions/index.html
@@ -81,8 +81,8 @@
 			<span class="description-preview">[description]</span>
 			<meta property="id" mv-default="[name]" />
 			<meta property="unary" mv-if="role = 'operator'" datatype="boolean" />
-			<span property="category" mv-edit="#categories"></span>
-			<span property="role" mv-edit="#role-select"></span>
+			<span property="category" mv-editor="#categories"></span>
+			<span property="role" mv-editor="#role-select"></span>
 		</summary>
 
 		<p property="description" class="markdown"></p>

--- a/docs/functions/index.tpl.html
+++ b/docs/functions/index.tpl.html
@@ -52,8 +52,8 @@
 			<span class="description-preview">[description]</span>
 			<meta property="id" mv-default="[name]" />
 			<meta property="unary" mv-if="role = 'operator'" datatype="boolean" />
-			<span property="category" mv-edit="#categories"></span>
-			<span property="role" mv-edit="#role-select"></span>
+			<span property="category" mv-editor="#categories"></span>
+			<span property="role" mv-editor="#role-select"></span>
 		</summary>
 
 		<p property="description" class="markdown"></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -82,7 +82,7 @@ thead th:first-child {
 				<td><code property="name"></code></td>
 				<td property="on" class="markdown"></td>
 				<td property="purpose" class="markdown"></td>
-				<td class="[if(live!='yes',if(live,semi,empty))]" property="live" mv-edit="#live"></td>
+				<td class="[if(live!='yes',if(live,semi,empty))]" property="live" mv-editor="#live"></td>
 				<td><a href="/docs/primer/#mv-app" property="path"><span property="link">url</span></a></td>
 			</tr>
 		</tbody>
@@ -113,7 +113,7 @@ thead th:first-child {
 				<td><code property="name"></code></td>
 				<td property="on" class="markdown"></td>
 				<td property="purpose" class="markdown"></td>
-				<td class="[if(live!='yes',if(live,semi,empty))]" property="live" mv-edit="#live"></td>
+				<td class="[if(live!='yes',if(live,semi,empty))]" property="live" mv-editor="#live"></td>
 				<td><a href="/docs/primer/#mv-app" property="path"><span property="link">url</span></a></td>
 			</tr>
 		</tbody>

--- a/docs/index.tpl.html
+++ b/docs/index.tpl.html
@@ -53,7 +53,7 @@ thead th:first-child {
 				<td><code property="name"></code></td>
 				<td property="on" class="markdown"></td>
 				<td property="purpose" class="markdown"></td>
-				<td class="[if(live!='yes',if(live,semi,empty))]" property="live" mv-edit="#live"></td>
+				<td class="[if(live!='yes',if(live,semi,empty))]" property="live" mv-editor="#live"></td>
 				<td><a href="/docs/primer/#mv-app" property="path"><span property="link">url</span></a></td>
 			</tr>
 		</tbody>
@@ -84,7 +84,7 @@ thead th:first-child {
 				<td><code property="name"></code></td>
 				<td property="on" class="markdown"></td>
 				<td property="purpose" class="markdown"></td>
-				<td class="[if(live!='yes',if(live,semi,empty))]" property="live" mv-edit="#live"></td>
+				<td class="[if(live!='yes',if(live,semi,empty))]" property="live" mv-editor="#live"></td>
 				<td><a href="/docs/primer/#mv-app" property="path"><span property="link">url</span></a></td>
 			</tr>
 		</tbody>


### PR DESCRIPTION
Since the new version of Mavo has been released, we can adopt `mv-editor*` on our site.