### PR TITLE
Some enhancements to the demos homepage

### DIFF
--- a/demos/demos.json
+++ b/demos/demos.json
@@ -164,7 +164,7 @@
 					"url": "/demos/invoice",
 					"description": "Showcases one of the many ways to make a \"multipage\" app that lets you open items to view more details without leaving the page. For actual multipage apps with different URLs, checkout the [Forkgasm](https://forkgasm.com) demo.",
 					"featured": false
-				}
+				},
 				{
 					"name": "Contact manager",
 					"tag": [

--- a/demos/demos.json
+++ b/demos/demos.json
@@ -1,209 +1,219 @@
 {
-	"demo": [
+	"category": [
 		{
-			"name": "To-Do List",
-			"tag": [
-				"Actions"
-			],
-			"id": "todo",
-			"description": "Showcases many Mavo features (properties, collections, data actions, local storage) in very little code.",
-			"video": "/demos/todo/video.mp4",
-			"url": "/demos/todo",
-			"featured": true
+			"name": "Basic",
+			"demo": [
+				{
+					"name": "To-Do List",
+					"tag": [
+						"Actions"
+					],
+					"id": "todo",
+					"description": "Showcases many Mavo features (properties, collections, data actions, local storage) in very little code.",
+					"video": "/demos/todo/video.mp4",
+					"url": "/demos/todo",
+					"featured": true
+				},
+				{
+					"name": "Artist Portfolio",
+					"tag": [
+						"Github",
+						"UPLOADS"
+					],
+					"id": "portfolio",
+					"description": "Artist portfolio with pictures and descriptions stored on Github. Showcases the various ways to edit images (linking, upload, copy/paste, drag & drop).",
+					"video": "/demos/portfolio/video.mp4",
+					"url": "/demos/portfolio",
+					"featured": false
+				},
+				{
+					"name": "Editable homepage",
+					"tag": [
+						"Github",
+						"TINYMCE"
+					],
+					"id": "homepage",
+					"description": "Uses the TinyMCE plugin for rich text editing.",
+					"video": "/demos/homepage/video.mp4",
+					"url": "/demos/homepage",
+					"featured": false
+				},
+				{
+					"name": "Mortgage Calculator",
+					"tag": [],
+					"id": "mortgage",
+					"video": "/demos/mortgage/video.mp4",
+					"url": "/demos/mortgage",
+					"description": "Showcases a more spreadsheet-like Mavo application.",
+					"featured": false
+				},
+				{
+					"name": "Color picker",
+					"tag": [],
+					"id": "color-picker",
+					"video": "/demos/color-picker/video.mp4",
+					"url": "/demos/color-picker",
+					"description": "An HSLA color picker. Showcases how responsive Mavo expressions are, as well as properties that depend on other properties.",
+					"featured": false
+				},
+				{
+					"name": "Interactive Mavo logo",
+					"tag": [
+						"SVG"
+					],
+					"id": "logo",
+					"video": "/demos/logo/video.mp4",
+					"url": "/demos/logo",
+					"description": "Showcases how well Mavo works with SVG.",
+					"featured": false
+				},
+				{
+					"name": "Shopping list",
+					"tag": [
+						"Actions"
+					],
+					"id": "shopping",
+					"video": "/demos/shopping/video.mp4",
+					"url": "/demos/shopping",
+					"description": "Showcases [custom data actions](/docs/actions) for copying items across lists, even if the lists don't have exactly the same structure.",
+					"featured": false
+				},
+				{
+					"name": "Dice roller with history",
+					"tag": [
+						"Actions"
+					],
+					"id": "dice",
+					"video": "/demos/dice/video.mp4",
+					"url": "/demos/dice",
+					"description": "Showcases [custom data actions](/docs/actions), including multiple data actions on the same control.",
+					"featured": false
+				},
+				{
+					"name": "Word game",
+					"tag": [
+						"Actions"
+					],
+					"id": "words",
+					"video": "/demos/words/video.mp4",
+					"url": "/demos/words",
+					"description": "A language learning game for two people, where one enters the phrase and the other tries to click on words to put them in the right order. Showcases [custom data actions](/docs/actions)",
+					"featured": false
+				}
+			]
 		},
 		{
-			"name": "Artist Portfolio",
-			"tag": [
-				"Github",
-				"UPLOADS"
-			],
-			"id": "portfolio",
-			"description": "Artist portfolio with pictures and descriptions stored on Github. Showcases the various ways to edit images (linking, upload, copy/paste, drag & drop).",
-			"video": "/demos/portfolio/video.mp4",
-			"url": "/demos/portfolio",
-			"featured": false
-		},
-		{
-			"name": "Editable homepage",
-			"tag": [
-				"Github",
-				"TINYMCE"
-			],
-			"id": "homepage",
-			"description": "Uses the TinyMCE plugin for rich text editing.",
-			"video": "/demos/homepage/video.mp4",
-			"url": "/demos/homepage",
-			"featured": false
-		},
-		{
-			"name": "E-shop",
-			"tag": [
-				"Actions",
-				"Github",
-				"Multiple Apps"
-			],
-			"id": "eshop",
-			"video": "/demos/eshop/video.mp4",
-			"url": "/demos/eshop",
-			"description": "Two Mavo apps: Product listing stored on Github, cart stored locally. Uses Paypal HTML API for checkout and a custom data action for adding to cart.",
-			"featured": true
-		},
-		{
-			"name": "Mortgage Calculator",
-			"tag": [],
-			"id": "mortgage",
-			"video": "/demos/mortgage/video.mp4",
-			"url": "/demos/mortgage",
-			"description": "Showcases a more spreadsheet-like Mavo application.",
-			"featured": false
-		},
-		{
-			"name": "Color picker",
-			"tag": [],
-			"id": "color-picker",
-			"video": "/demos/color-picker/video.mp4",
-			"url": "/demos/color-picker",
-			"description": "An HSLA color picker. Showcases how responsive Mavo expressions are, as well as properties that depend on other properties.",
-			"featured": false
-		},
-		{
-			"name": "Decisions",
-			"tag": [
-				"Hierarchy"
-			],
-			"id": "decisions",
-			"video": "/demos/decisions/video.mp4",
-			"url": "/demos/decisions",
-			"description": "An app to list pros and cons (with weights!) to help you make a decision.",
-			"featured": false
-		},
-		{
-			"name": "Restaurant visit log",
-			"tag": [
-				"Hierarchy"
-			],
-			"id": "foodie",
-			"video": "/demos/foodie/video.mp4",
-			"url": "/demos/foodie",
-			"description": "Showcases hierarchy (3 levels of nested collections) and how scoping works with it in expressions.",
-			"featured": false
-		},
-		{
-			"name": "Interactive Mavo logo",
-			"tag": [
-				"SVG"
-			],
-			"id": "logo",
-			"video": "/demos/logo/video.mp4",
-			"url": "/demos/logo",
-			"description": "Showcases how well Mavo works with SVG.",
-			"featured": false
-		},
-		{
-			"name": "Talks list",
-			"tag": [
-				"Hierarchy",
-				"Github"
-			],
-			"id": "talks",
-			"video": "/demos/talks/video.mp4",
-			"url": "/demos/talks",
-			"description": "The first Mavo demo ever created. Showcases dates and expressions with dates. See a similar app in action on [Lea Verou's website](http://lea.verou.me/speaking) and [Chris Lilley's website](http://svgees.us/talks.html)",
-			"featured": false
-		},
-		{
-			"name": "Invoicing system",
-			"tag": [
-				"Hierarchy",
-				"Multipage",
-				"Github"
-			],
-			"id": "invoice",
-			"video": "/demos/invoice/video.mp4",
-			"url": "/demos/invoice",
-			"description": "Showcases one of the many ways to make a \"multipage\" app that lets you open items to view more details without leaving the page. For actual multipage apps with different URLs, checkout the [Forkgasm](https://forkgasm.com) demo.",
-			"featured": false
-		},
-		{
-			"name": "SVG Path builder",
-			"tag": [
-				"SVG",
-				"mv-if"
-			],
-			"id": "svgpath",
-			"video": "/demos/svgpath/video.mp4",
-			"url": "/demos/svgpath",
-			"description": "One of the most complex demos, showcases `mv-if` for conditionals, dynamic default values, custom UI, Mavo expressions in SVG",
-			"featured": false
-		},
-		{
-			"name": "Contact manager",
-			"tag": [
-				"Hierarchy"
-			],
-			"id": "contacts",
-			"video": "/demos/contacts/video.mp4",
-			"url": "/demos/contacts",
-			"description": "A replica of a contact list app, with multiple emails and phone numbers per person.",
-			"featured": false
-		},
-		{
-			"name": "Shopping list",
-			"tag": [
-				"Actions"
-			],
-			"id": "shopping",
-			"video": "/demos/shopping/video.mp4",
-			"url": "/demos/shopping",
-			"description": "Showcases [custom data actions](/docs/actions) for copying items across lists, even if the lists don't have exactly the same structure.",
-			"featured": false
-		},
-		{
-			"name": "Dice roller with history",
-			"tag": [
-				"Actions"
-			],
-			"id": "dice",
-			"video": "/demos/dice/video.mp4",
-			"url": "/demos/dice",
-			"description": "Showcases [custom data actions](/docs/actions), including multiple data actions on the same control.",
-			"featured": false
-		},
-		{
-			"name": "Word game",
-			"tag": [
-				"Actions"
-			],
-			"id": "words",
-			"video": "/demos/words/video.mp4",
-			"url": "/demos/words",
-			"description": "A language learning game for two people, where one enters the phrase and the other tries to click on words to put them in the right order. Showcases [custom data actions](/docs/actions)",
-			"featured": false
-		},
-		{
-			"url": "https://forkgasm.com",
-			"name": "Forkgasm Food Blog",
-			"featured": true,
-			"description": "Food blog with recipes and restaurant visits. Showcases how you can use Mavo to have truly multipage apps with different URLs (thanks to [Netlify's URL rewrite rules](https://www.netlify.com/docs/redirects/))",
-			"tag": [
-				"Multipage",
-				"Github"
-			],
-			"id": "forkgasm",
-			"image": "https://mavo.io/demos/images/forkgasm.png"
-		},
-		{
-			"url": "https://dmitrysharabin.github.io/mavo-memory-game/",
-			"name": "Memory Game",
-			"featured": true,
-			"description": "A card matching game (also known as [Concentration](https://en.wikipedia.org/wiki/Concentration_(game))). Showcases a way to divide an app's features between separate Mavo apps (game state, game board, themes, attempts stats), [UI customization](/docs/ui), and [custom data actions](/docs/actions) (including multiple data actions on the same control).",
-			"tag": [
-				"Actions",
-				"Multiple Apps",
-				"Hierarchy"
-			],
-			"id": "memory-game",
-			"video": "https://dmitrysharabin.github.io/mavo-memory-game/video_short.mp4"
+			"name": "Complex",
+			"demo": [
+				{
+					"name": "E-shop",
+					"tag": [
+						"Actions",
+						"Github",
+						"Multiple Apps"
+					],
+					"id": "eshop",
+					"video": "/demos/eshop/video.mp4",
+					"url": "/demos/eshop",
+					"description": "Two Mavo apps: Product listing stored on Github, cart stored locally. Uses Paypal HTML API for checkout and a custom data action for adding to cart.",
+					"featured": true
+				},
+				{
+					"name": "Decisions",
+					"tag": [
+						"Hierarchy"
+					],
+					"id": "decisions",
+					"video": "/demos/decisions/video.mp4",
+					"url": "/demos/decisions",
+					"description": "An app to list pros and cons (with weights!) to help you make a decision.",
+					"featured": false
+				},
+				{
+					"name": "Restaurant visit log",
+					"tag": [
+						"Hierarchy"
+					],
+					"id": "foodie",
+					"video": "/demos/foodie/video.mp4",
+					"url": "/demos/foodie",
+					"description": "Showcases hierarchy (3 levels of nested collections) and how scoping works with it in expressions.",
+					"featured": false
+				},
+				{
+					"name": "Talks list",
+					"tag": [
+						"Hierarchy",
+						"Github"
+					],
+					"id": "talks",
+					"video": "/demos/talks/video.mp4",
+					"url": "/demos/talks",
+					"description": "The first Mavo demo ever created. Showcases dates and expressions with dates. See a similar app in action on [Lea Verou's website](http://lea.verou.me/speaking) and [Chris Lilley's website](http://svgees.us/talks.html)",
+					"featured": false
+				},
+				{
+					"name": "Invoicing system",
+					"tag": [
+						"Hierarchy",
+						"Multipage",
+						"Github"
+					],
+					"id": "invoice",
+					"video": "/demos/invoice/video.mp4",
+					"url": "/demos/invoice",
+					"description": "Showcases one of the many ways to make a \"multipage\" app that lets you open items to view more details without leaving the page. For actual multipage apps with different URLs, checkout the [Forkgasm](https://forkgasm.com) demo.",
+					"featured": false
+				},
+				{
+					"name": "SVG Path builder",
+					"tag": [
+						"SVG",
+						"mv-if"
+					],
+					"id": "svgpath",
+					"video": "/demos/svgpath/video.mp4",
+					"url": "/demos/svgpath",
+					"description": "One of the most complex demos, showcases `mv-if` for conditionals, dynamic default values, custom UI, Mavo expressions in SVG",
+					"featured": false
+				},
+				{
+					"name": "Contact manager",
+					"tag": [
+						"Hierarchy"
+					],
+					"id": "contacts",
+					"video": "/demos/contacts/video.mp4",
+					"url": "/demos/contacts",
+					"description": "A replica of a contact list app, with multiple emails and phone numbers per person.",
+					"featured": false
+				},
+				{
+					"url": "https://forkgasm.com",
+					"name": "Forkgasm Food Blog",
+					"featured": true,
+					"description": "Food blog with recipes and restaurant visits. Showcases how you can use Mavo to have truly multipage apps with different URLs (thanks to [Netlify's URL rewrite rules](https://www.netlify.com/docs/redirects/))",
+					"tag": [
+						"Multipage",
+						"Github"
+					],
+					"id": "forkgasm",
+					"image": "https://mavo.io/demos/images/forkgasm.png"
+				},
+				{
+					"url": "https://dmitrysharabin.github.io/mavo-memory-game/",
+					"name": "Memory Game",
+					"featured": true,
+					"description": "A card matching game (also known as [Concentration](https://en.wikipedia.org/wiki/Concentration_(game))). Showcases a way to divide an app's features between separate Mavo apps (game state, game board, themes, attempts stats), [UI customization](/docs/ui), and [custom data actions](/docs/actions) (including multiple data actions on the same control).",
+					"tag": [
+						"Actions",
+						"Multiple Apps",
+						"Hierarchy"
+					],
+					"id": "memory-game",
+					"video": "https://dmitrysharabin.github.io/mavo-memory-game/video_short.mp4"
+				}
+			]
 		}
 	]
 }

--- a/demos/demos.json
+++ b/demos/demos.json
@@ -1,7 +1,7 @@
 {
 	"category": [
 		{
-			"name": "Basic",
+			"name": "Basic demos",
 			"demo": [
 				{
 					"name": "To-Do List",
@@ -103,7 +103,7 @@
 			]
 		},
 		{
-			"name": "Complex",
+			"name": "Complex demos",
 			"demo": [
 				{
 					"name": "E-shop",
@@ -164,19 +164,7 @@
 					"url": "/demos/invoice",
 					"description": "Showcases one of the many ways to make a \"multipage\" app that lets you open items to view more details without leaving the page. For actual multipage apps with different URLs, checkout the [Forkgasm](https://forkgasm.com) demo.",
 					"featured": false
-				},
-				{
-					"name": "SVG Path builder",
-					"tag": [
-						"SVG",
-						"mv-if"
-					],
-					"id": "svgpath",
-					"video": "/demos/svgpath/video.mp4",
-					"url": "/demos/svgpath",
-					"description": "One of the most complex demos, showcases `mv-if` for conditionals, dynamic default values, custom UI, Mavo expressions in SVG",
-					"featured": false
-				},
+				}
 				{
 					"name": "Contact manager",
 					"tag": [
@@ -199,6 +187,23 @@
 					],
 					"id": "forkgasm",
 					"image": "https://mavo.io/demos/images/forkgasm.png"
+				}
+			]
+		},
+		{
+			"name": "Full applications",
+			"demo": [
+				{
+					"name": "SVG Path builder",
+					"tag": [
+						"SVG",
+						"mv-if"
+					],
+					"id": "svgpath",
+					"video": "/demos/svgpath/video.mp4",
+					"url": "/demos/svgpath",
+					"description": "One of the most complex demos, showcases `mv-if` for conditionals, dynamic default values, custom UI, Mavo expressions in SVG",
+					"featured": false
 				},
 				{
 					"url": "https://dmitrysharabin.github.io/mavo-memory-game/",

--- a/demos/index.html
+++ b/demos/index.html
@@ -40,26 +40,31 @@
 	<p class="notice" mv-if="tagFilter">
 		Some demos are hidden. <a href="?">Show All.</a>
 	</p>
-	<div>
-		<article property="demo" mv-multiple mv-if="!tagFilter or count(tag = tagFilter) > 0" id="demo-[id]"
-		         class="[if(featured, 'featured')] [if(video, 'has-video')] [if(starts(url, 'http'), 'external')]">
-			<a href="[url]" class="media-container">
-				<video property="video" preload="metadata" loop muted tabindex="0"></video>
-				<img property="image">
-			</a>
-			<div>
-				<a mv-default="/demos/[id]" property="url">
-					<h1>
-						<span property="name"></span>
-						<span class="mv-toggle" property="featured">Featured</span>
-					</h1>
+
+	<details property="category" mv-multiple open>
+		<summary property="name">Category</summary>
+
+		<div>
+			<article property="demo" mv-multiple mv-if="!tagFilter or count(tag = tagFilter) > 0" id="demo-[id]"
+								class="[if(featured, 'featured')] [if(video, 'has-video')] [if(starts(url, 'http'), 'external')]">
+				<a href="[url]" class="media-container">
+					<video property="video" preload="metadata" loop muted tabindex="0"></video>
+					<img property="image">
 				</a>
-				<div class="markdown" property="description"></div>
-				<a href="?tag=[tag]" property="tag" mv-attribute="none" mv-multiple title="See only demos with the [tag] tag"></a>
-				<meta property="id">
-			</div>
-		</article>
-	</div>
+				<div>
+					<a mv-default="/demos/[id]" property="url">
+						<h1>
+							<span property="name"></span>
+							<span class="mv-toggle" property="featured">Featured</span>
+						</h1>
+					</a>
+					<div class="markdown" property="description"></div>
+					<a href="?tag=[tag]" property="tag" mv-attribute="none" mv-multiple title="See only demos with the [tag] tag"></a>
+					<meta property="id">
+				</div>
+			</article>
+		</div>
+	</details>
 
 	<p class="tip">Use <code>?storage=<em>your_path</em></code> in the URL of any of these demos to change its data source! <a href="/docs/storage/#url-params">Learn More</a></p>
 </section>

--- a/demos/index.html
+++ b/demos/index.html
@@ -69,14 +69,10 @@
 	<p class="tip">Use <code>?storage=<em>your_path</em></code> in the URL of any of these demos to change its data source! <a href="/docs/storage/#url-params">Learn More</a></p>
 </section>
 
-<section>
+<section mv-app="mavos" mv-storage="https://github.com/mavoweb/mavo.io/demos/mavos.json" mv-storage-branch="master" mv-bar="no-login">
 	<h1>Mavo in the wild</h1>
 	<ul>
-		<li><a href="http://laistomaz.com/">Blog using Mavo & Disqus for comments</a></li>
-		<li><a href="https://drafts.csswg.org/issues?spec=css-images-3&doc=cr-2012">W3C CSS WG, Disposition of Comments tool</a></li>
-		<li><a href="http://www.ekia.net/">Martial Arts School website</a></li>
-		<li><a href="http://mattfredfry.com/calculator/">Calculators</a></li>
-		<li><a href="https://codepen.io/collection/nvggyQ/">Mavo demos on Codepen</a></li>
+		<li property="link" mv-multiple><a href="" property="url"><span property="description"></span></a></li>
 	</ul>
 	<p>Made a cool Mavo app? We'd love to see it and feature it here, please <a href="http://github.com/mavoweb/mavo/issues">get in touch</a>!</p>
 </section>

--- a/demos/index.tpl.html
+++ b/demos/index.tpl.html
@@ -9,26 +9,31 @@
 	<p class="notice" mv-if="tagFilter">
 		Some demos are hidden. <a href="?">Show All.</a>
 	</p>
-	<div>
-		<article property="demo" mv-multiple mv-if="!tagFilter or count(tag = tagFilter) > 0" id="demo-[id]"
-		         class="[if(featured, 'featured')] [if(video, 'has-video')] [if(starts(url, 'http'), 'external')]">
-			<a href="[url]" class="media-container">
-				<video property="video" preload="metadata" loop muted tabindex="0"></video>
-				<img property="image">
-			</a>
-			<div>
-				<a mv-default="/demos/[id]" property="url">
-					<h1>
-						<span property="name"></span>
-						<span class="mv-toggle" property="featured">Featured</span>
-					</h1>
+
+	<details property="category" mv-multiple open>
+		<summary property="name">Category</summary>
+
+		<div>
+			<article property="demo" mv-multiple mv-if="!tagFilter or count(tag = tagFilter) > 0" id="demo-[id]"
+								class="[if(featured, 'featured')] [if(video, 'has-video')] [if(starts(url, 'http'), 'external')]">
+				<a href="[url]" class="media-container">
+					<video property="video" preload="metadata" loop muted tabindex="0"></video>
+					<img property="image">
 				</a>
-				<div class="markdown" property="description"></div>
-				<a href="?tag=[tag]" property="tag" mv-attribute="none" mv-multiple title="See only demos with the [tag] tag"></a>
-				<meta property="id">
-			</div>
-		</article>
-	</div>
+				<div>
+					<a mv-default="/demos/[id]" property="url">
+						<h1>
+							<span property="name"></span>
+							<span class="mv-toggle" property="featured">Featured</span>
+						</h1>
+					</a>
+					<div class="markdown" property="description"></div>
+					<a href="?tag=[tag]" property="tag" mv-attribute="none" mv-multiple title="See only demos with the [tag] tag"></a>
+					<meta property="id">
+				</div>
+			</article>
+		</div>
+	</details>
 
 	<p class="tip">Use <code>?storage=<em>your_path</em></code> in the URL of any of these demos to change its data source! <a href="/docs/storage/#url-params">Learn More</a></p>
 </section>

--- a/demos/index.tpl.html
+++ b/demos/index.tpl.html
@@ -38,14 +38,10 @@
 	<p class="tip">Use <code>?storage=<em>your_path</em></code> in the URL of any of these demos to change its data source! <a href="/docs/storage/#url-params">Learn More</a></p>
 </section>
 
-<section>
+<section mv-app="mavos" mv-storage="https://github.com/mavoweb/mavo.io/demos/mavos.json" mv-storage-branch="master" mv-bar="no-login">
 	<h1>Mavo in the wild</h1>
 	<ul>
-		<li><a href="http://laistomaz.com/">Blog using Mavo & Disqus for comments</a></li>
-		<li><a href="https://drafts.csswg.org/issues?spec=css-images-3&doc=cr-2012">W3C CSS WG, Disposition of Comments tool</a></li>
-		<li><a href="http://www.ekia.net/">Martial Arts School website</a></li>
-		<li><a href="http://mattfredfry.com/calculator/">Calculators</a></li>
-		<li><a href="https://codepen.io/collection/nvggyQ/">Mavo demos on Codepen</a></li>
+		<li property="link" mv-multiple><a href="" property="url"><span property="description"></span></a></li>
 	</ul>
 	<p>Made a cool Mavo app? We'd love to see it and feature it here, please <a href="http://github.com/mavoweb/mavo/issues">get in touch</a>!</p>
 </section>

--- a/demos/mavos.json
+++ b/demos/mavos.json
@@ -1,0 +1,24 @@
+{
+	"link": [
+		{
+			"url": "http://laistomaz.com/",
+			"description": "Blog using Mavo & Disqus for comments"
+		},
+		{
+			"url": "https://drafts.csswg.org/issues?spec=css-images-3&doc=cr-2012",
+			"description": "W3C CSS WG, Disposition of Comments tool"
+		},
+		{
+			"url": "http://www.ekia.net/",
+			"description": "Martial Arts School website"
+		},
+		{
+			"url": "http://mattfredfry.com/calculator/",
+			"description": "Calculators"
+		},
+		{
+			"url": "https://codepen.io/collection/nvggyQ/",
+			"description": "Mavo demos on Codepen"
+		}
+	]
+}

--- a/demos/style.css
+++ b/demos/style.css
@@ -181,6 +181,34 @@ article:not(.featured) [mv-app=demos] [property=video].playing {
   opacity: 0.7;
 }
 
+@media (max-width: 420px) {
+  nav {
+    margin-left: 1.5em;
+  }
+
+  section[mv-app=demos] {
+    margin: 0;
+  }
+  section[mv-app=demos] > details > summary {
+    font-size: 170%;
+  }
+  section[mv-app=demos] > details > div {
+    grid-template-columns: 1fr;
+  }
+
+  article[property=demo] {
+    flex-flow: column;
+  }
+  article[property=demo] .media-container {
+    width: 100%;
+  }
+  article[property=demo] > div {
+    padding: 0;
+  }
+  article[property=demo] h1 {
+    font-size: 150%;
+  }
+}
 html:not(.lite) body:not(.has-demo-bar) main {
   padding: 1rem;
   margin: 1rem 1rem 2rem;

--- a/demos/style.css
+++ b/demos/style.css
@@ -10,7 +10,18 @@ section[mv-app=demos] {
 section[mv-app=demos][mv-permissions~=login] > .mv-bar {
   display: none;
 }
-section[mv-app=demos] > div {
+section[mv-app=demos] > details + details {
+  margin-top: 1.5em;
+}
+section[mv-app=demos] > details > summary {
+  margin-bottom: 0.5em;
+  font: bold 200% Didot, "Didot LT STD", "Bodoni 72", Bodoni, "Bodoni MT", "Libre Bodoni", "Hoefler Text", Cambria, Georgia, serif;
+  color: #ff9500;
+}
+section[mv-app=demos] > details > summary::after {
+  content: " demos";
+}
+section[mv-app=demos] > details > div {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(29rem, 1fr));
   grid-auto-flow: dense;

--- a/demos/style.css
+++ b/demos/style.css
@@ -18,9 +18,6 @@ section[mv-app=demos] > details > summary {
   font: bold 200% Didot, "Didot LT STD", "Bodoni 72", Bodoni, "Bodoni MT", "Libre Bodoni", "Hoefler Text", Cambria, Georgia, serif;
   color: #ff9500;
 }
-section[mv-app=demos] > details > summary::after {
-  content: " demos";
-}
 section[mv-app=demos] > details > div {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(29rem, 1fr));

--- a/demos/style.css
+++ b/demos/style.css
@@ -16,7 +16,7 @@ section[mv-app=demos] > details + details {
 section[mv-app=demos] > details > summary {
   margin-bottom: 0.5em;
   font: bold 200% Didot, "Didot LT STD", "Bodoni 72", Bodoni, "Bodoni MT", "Libre Bodoni", "Hoefler Text", Cambria, Georgia, serif;
-  color: #ff9500;
+  color: #25aff4;
 }
 section[mv-app=demos] > details > div {
   display: grid;

--- a/demos/style.scss
+++ b/demos/style.scss
@@ -12,13 +12,29 @@ section[mv-app="demos"] {
 		display: none;
 	}
 
-	& > div {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(29rem, 1fr));
-		grid-auto-flow: dense;
-		grid-gap: 1.2em;
-		margin: auto;
-		width: 100%;
+	& > details {
+		& + details {
+			margin-top: 1.5em;
+		}
+
+		& > summary {
+			margin-bottom: 0.5em;
+			font: bold 200% $heading-font;
+			color: $orange;
+
+			&::after {
+				content: " demos";
+			}
+		}
+
+		& > div {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(29rem, 1fr));
+			grid-auto-flow: dense;
+			grid-gap: 1.2em;
+			margin: auto;
+			width: 100%;
+		}
 	}
 }
 

--- a/demos/style.scss
+++ b/demos/style.scss
@@ -20,7 +20,7 @@ section[mv-app="demos"] {
 		& > summary {
 			margin-bottom: 0.5em;
 			font: bold 200% $heading-font;
-			color: $orange;
+			color: $blue;
 		}
 
 		& > div {

--- a/demos/style.scss
+++ b/demos/style.scss
@@ -21,10 +21,6 @@ section[mv-app="demos"] {
 			margin-bottom: 0.5em;
 			font: bold 200% $heading-font;
 			color: $orange;
-
-			&::after {
-				content: " demos";
-			}
 		}
 
 		& > div {

--- a/demos/style.scss
+++ b/demos/style.scss
@@ -210,6 +210,42 @@ article[property="demo"] {
 	}
 }
 
+@media (max-width: 420px) {
+	nav {
+		margin-left: 1.5em;
+	}
+
+	section[mv-app="demos"] {
+		margin: 0;
+
+		& > details {
+			& > summary {
+				font-size: 170%;
+			}
+
+			& > div {
+				grid-template-columns: 1fr;
+			}
+		}
+	}
+
+	article[property="demo"] {
+		flex-flow: column;
+
+		.media-container {
+			width: 100%;
+		}
+
+		& > div {
+			padding: 0;
+		}
+
+		h1 {
+			font-size: 150%;
+		}
+	}
+}
+
 html:not(.lite) body:not(.has-demo-bar) main {
 	padding: 1rem;
 	margin: 1rem 1rem 2rem;

--- a/demos/todo/index.html
+++ b/demos/todo/index.html
@@ -4,6 +4,7 @@
 
 <meta charset="UTF-8">
 <title>To-Do List</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://get.mavo.io/stable/mavo.min.css">
 <script src="https://get.mavo.io/stable/mavo.es5.min.js"></script>
 <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
What I did:
- split all demos into two categories: _Basic demos_ and _Complex demos_
- refactored `demos.json` to make the first point happen
- converted the _Mavo in the wild_ section into a separate app so that we could work with it effortlessly. We need to update it eventually btw (see https://github.com/mavoweb/mavo/issues/726).

Please feel free to rearrange the demos the way you like. I'm not sure I've split them the way you imagined. :)