### PR TITLE
Add “Action” category

### DIFF
--- a/docs/functions/index.html
+++ b/docs/functions/index.html
@@ -54,6 +54,7 @@
 			<select property="roleFilter" mv-default="[url('role')]" mv-storage="none">
 				<option value="">Show all terms</option>
 				<option value="function">Function</option>
+				<option value="action">Action</option>
 				<option value="special">Special Property</option>
 				<option value="operator">Operator</option>
 			</select>
@@ -138,6 +139,7 @@
 <div hidden>
 	<select id="role-select">
 		<option value="function">Function</option>
+		<option value="action">Action</option>
 		<option value="special">Special Property</option>
 		<option value="operator">Operator</option>
 	</select>

--- a/docs/functions/index.tpl.html
+++ b/docs/functions/index.tpl.html
@@ -25,6 +25,7 @@
 			<select property="roleFilter" mv-default="[url('role')]" mv-storage="none">
 				<option value="">Show all terms</option>
 				<option value="function">Function</option>
+				<option value="action">Action</option>
 				<option value="special">Special Property</option>
 				<option value="operator">Operator</option>
 			</select>
@@ -109,6 +110,7 @@
 <div hidden>
 	<select id="role-select">
 		<option value="function">Function</option>
+		<option value="action">Action</option>
 		<option value="special">Special Property</option>
 		<option value="operator">Operator</option>
 	</select>

--- a/docs/style.css
+++ b/docs/style.css
@@ -395,10 +395,13 @@ table.attributes td:nth-last-child(2):empty::before {
 [mv-app=functions] [id=functions] details[property=term].role-operator {
   --color: #ff0080;
 }
-[mv-app=api] [id=api] details[property=member].role-accessor,
+[mv-app=api] [id=api] details[property=member].role-accessor, [mv-app=api] [id=api] details[property=member].role-action,
 [mv-app=api] [id=api] details[property=term].role-accessor,
+[mv-app=api] [id=api] details[property=term].role-action,
 [mv-app=functions] [id=functions] details[property=member].role-accessor,
-[mv-app=functions] [id=functions] details[property=term].role-accessor {
+[mv-app=functions] [id=functions] details[property=member].role-action,
+[mv-app=functions] [id=functions] details[property=term].role-accessor,
+[mv-app=functions] [id=functions] details[property=term].role-action {
   --color: #ff9500;
 }
 [mv-app=api] [id=api] details[property=member].role-function,

--- a/docs/style.scss
+++ b/docs/style.scss
@@ -418,7 +418,8 @@ table.attributes {
 			--color: #{$magenta};
 		}
 
-		&.role-accessor {
+		&.role-accessor,
+		&.role-action {
 			--color: #{$orange};
 		}
 


### PR DESCRIPTION
We need this to be able to add the `set()`, `add()`, `move()`, and `delete()` action functions to the [All functions](https://mavo.io/docs/functions/) section of the docs.